### PR TITLE
Expose Dependency Declarations with ANTLR parsing context for manipulation

### DIFF
--- a/core/src/main/kotlin/cash/grammar/kotlindsl/model/DependencyDeclarationWithContext.kt
+++ b/core/src/main/kotlin/cash/grammar/kotlindsl/model/DependencyDeclarationWithContext.kt
@@ -1,0 +1,8 @@
+package cash.grammar.kotlindsl.model
+
+import com.squareup.cash.grammar.KotlinParser.StatementContext
+
+public data class DependencyDeclarationWithContext(
+  val declaration: DependencyDeclaration,
+  val statement: StatementContext
+)

--- a/core/src/main/kotlin/cash/grammar/kotlindsl/model/DependencyDeclarationWithContext.kt
+++ b/core/src/main/kotlin/cash/grammar/kotlindsl/model/DependencyDeclarationWithContext.kt
@@ -1,8 +1,0 @@
-package cash.grammar.kotlindsl.model
-
-import com.squareup.cash.grammar.KotlinParser.StatementContext
-
-public data class DependencyDeclarationWithContext(
-  val declaration: DependencyDeclaration,
-  val statement: StatementContext
-)

--- a/core/src/main/kotlin/cash/grammar/kotlindsl/model/DependencyElement.kt
+++ b/core/src/main/kotlin/cash/grammar/kotlindsl/model/DependencyElement.kt
@@ -1,0 +1,28 @@
+package cash.grammar.kotlindsl.model
+
+import com.squareup.cash.grammar.KotlinParser.StatementContext
+
+/**
+ * Base class representing an element within the `dependencies` block.
+ *
+ * @property statement The context of the statement in the dependencies block.
+ */
+public sealed class DependencyElement(public open val statement: StatementContext)
+
+/**
+ * Represents a dependency declaration within the `dependencies` block.
+ *
+ * @property declaration The parsed dependency declaration.
+ * @property statement The context of the statement in the dependencies block.
+ */
+public data class DependencyDeclarationElement(
+  val declaration: DependencyDeclaration,
+  override val statement: StatementContext
+) : DependencyElement(statement)
+
+/**
+ * Represents a statement within the `dependencies` block that is **not** a dependency declaration.
+ *
+ * @property statement The context of the statement within the dependencies block.
+ */
+public data class NonDependencyDeclarationElement(override val statement: StatementContext) : DependencyElement(statement)

--- a/core/src/main/kotlin/cash/grammar/kotlindsl/model/gradle/DependencyContainer.kt
+++ b/core/src/main/kotlin/cash/grammar/kotlindsl/model/gradle/DependencyContainer.kt
@@ -1,36 +1,33 @@
 package cash.grammar.kotlindsl.model.gradle
 
-import cash.grammar.kotlindsl.model.DependencyDeclaration
-import cash.grammar.kotlindsl.model.DependencyDeclarationWithContext
+import cash.grammar.kotlindsl.model.*
 import com.squareup.cash.grammar.KotlinParser.StatementContext
 
 /**
  * A container for all the [Statements][com.squareup.cash.grammar.KotlinParser.StatementsContext] in
  * a `dependencies` block in a Gradle build script. These statements are an ordered (not sorted!)
- * list of "raw" statements and modeled
- * [DependencyDeclarations][cash.grammar.kotlindsl.model.DependencyDeclaration].
+ * list of statements, each classified as a [DependencyElement]
  *
- * Rather than attempt to model everything that might possibly be found inside a build script, we
- * declare defeat on anything that isn't a standard dependency declaration and simply retain it
- * as-is.
+ * Each statement in this container is classified as a [DependencyElement], which can represent either:
+ * - A parsed [DependencyDeclaration][cash.grammar.kotlindsl.model.DependencyDeclaration] element, or
+ * - A non-dependency declaration statement, retained as-is.
  */
 public class DependencyContainer(
-  /** The raw, ordered, list of statements for more complex use-cases. */
-  public val elements: List<Any>,
+  /** The ordered list of [DependencyElement] instances, representing each classified statement within the `dependencies` block. */
+  public val elements: List<DependencyElement>,
 ) {
 
-  public fun getDependencyDeclarationsWithContext(): List<DependencyDeclarationWithContext> {
-    return elements.filterIsInstance<DependencyDeclarationWithContext>()
+  public fun getDependencyDeclarationsWithContext(): List<DependencyDeclarationElement> {
+    return elements.filterIsInstance<DependencyDeclarationElement>()
   }
 
   public fun getDependencyDeclarations(): List<DependencyDeclaration> {
-    val declarationsWithContext = getDependencyDeclarationsWithContext().map { it.declaration }
-    return declarationsWithContext.ifEmpty {
-      elements.filterIsInstance<DependencyDeclaration>()
-    }
+    return getDependencyDeclarationsWithContext().map { it.declaration }
   }
 
   /**
+   * Get non-dependency declaration statements.
+   *
    * Might include an [if-expression][com.squareup.cash.grammar.KotlinParser.IfExpressionContext] like
    * ```
    * if (functionReturningABoolean()) { ... }
@@ -45,7 +42,7 @@ public class DependencyContainer(
    * ```
    */
   public fun getStatements(): List<StatementContext> {
-    return elements.filterIsInstance<StatementContext>()
+    return elements.filterIsInstance<NonDependencyDeclarationElement>().map { it.statement }
   }
 
   internal companion object {

--- a/core/src/main/kotlin/cash/grammar/kotlindsl/model/gradle/DependencyContainer.kt
+++ b/core/src/main/kotlin/cash/grammar/kotlindsl/model/gradle/DependencyContainer.kt
@@ -1,6 +1,7 @@
 package cash.grammar.kotlindsl.model.gradle
 
 import cash.grammar.kotlindsl.model.DependencyDeclaration
+import cash.grammar.kotlindsl.model.DependencyDeclarationWithContext
 import com.squareup.cash.grammar.KotlinParser.StatementContext
 
 /**
@@ -18,26 +19,15 @@ public class DependencyContainer(
   public val elements: List<Any>,
 ) {
 
+  public fun getDependencyDeclarationsWithContext(): List<DependencyDeclarationWithContext> {
+    return elements.filterIsInstance<DependencyDeclarationWithContext>()
+  }
+
   public fun getDependencyDeclarations(): List<DependencyDeclaration> {
-    return elements.filterIsInstance<DependencyDeclaration>()
-  }
-
-  @Deprecated(
-    message = "use getExpressions",
-    replaceWith = ReplaceWith("getExpressions()")
-  )
-  public fun getNonDeclarations(): List<String> {
-    return getExpressions()
-  }
-
-  /**
-   * A common example of an expression in a dependencies block is
-   * ```
-   * add("extraImplementation", "com.foo:bar:1.0")
-   * ```
-   */
-  public fun getExpressions(): List<String> {
-    return elements.filterIsInstance<String>()
+    val declarationsWithContext = getDependencyDeclarationsWithContext().map { it.declaration }
+    return declarationsWithContext.ifEmpty {
+      elements.filterIsInstance<DependencyDeclaration>()
+    }
   }
 
   /**
@@ -48,6 +38,10 @@ public class DependencyContainer(
    * or a [property declaration][com.squareup.cash.grammar.KotlinParser.PropertyDeclarationContext] like
    * ```
    * val string = "a:complex:$value"
+   * ```
+   * or a common example of an expression in a dependencies block like
+   * ```
+   * add("extraImplementation", "com.foo:bar:1.0")
    * ```
    */
   public fun getStatements(): List<StatementContext> {

--- a/core/src/main/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractor.kt
+++ b/core/src/main/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractor.kt
@@ -58,6 +58,28 @@ public class DependencyExtractor(
   }
 
   /**
+   * Given that we're inside a `dependencies {}` block, collect the set of dependencies with their context.
+   */
+  public fun collectDependencyDeclarationsWithContext(ctx: NamedBlockContext): List<Pair<DependencyDeclaration, PostfixUnaryExpressionContext>> {
+    require(ctx.isDependencies) {
+      "Expected dependencies block. Was '${ctx.name().text}'"
+    }
+
+    val statements = ctx.statements().statement()
+    if (statements.isNullOrEmpty()) return emptyList()
+
+    return statements.mapNotNull { stmt ->
+      val leaf = stmt.leafRule()
+      if (leaf is PostfixUnaryExpressionContext) {
+        val dependency = parseDependencyDeclaration(leaf) as? DependencyDeclaration
+        dependency?.let { it to leaf }
+      } else {
+        null
+      }
+    }
+  }
+
+  /**
    * Given that we're inside `buildscript { dependencies { ... } }`, collect all of the `classpath`
    * dependencies.
    *

--- a/core/src/main/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractor.kt
+++ b/core/src/main/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractor.kt
@@ -59,28 +59,6 @@ public class DependencyExtractor(
   }
 
   /**
-   * Given that we're inside a `dependencies {}` block, collect the set of dependencies with their context.
-   */
-  public fun collectDependencyDeclarationsWithContext(ctx: NamedBlockContext): List<Pair<DependencyDeclaration, PostfixUnaryExpressionContext>> {
-    require(ctx.isDependencies) {
-      "Expected dependencies block. Was '${ctx.name().text}'"
-    }
-
-    val statements = ctx.statements().statement()
-    if (statements.isNullOrEmpty()) return emptyList()
-
-    return statements.mapNotNull { stmt ->
-      val leaf = stmt.leafRule()
-      if (leaf is PostfixUnaryExpressionContext) {
-        val dependency = parseDependencyDeclaration(leaf) as? DependencyDeclaration
-        dependency?.let { it to leaf }
-      } else {
-        null
-      }
-    }
-  }
-
-  /**
    * Given that we're inside `buildscript { dependencies { ... } }`, collect all of the `classpath`
    * dependencies.
    *

--- a/core/src/test/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractorTest.kt
+++ b/core/src/test/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractorTest.kt
@@ -28,6 +28,7 @@ internal class DependencyExtractorTest {
 
     // Then
     assertThat(scriptListener.dependencyDeclarations).containsExactly(testCase.toDependencyDeclaration())
+    assertThat(scriptListener.dependencyDeclarationsStatements).containsExactly(testCase.fullText)
   }
 
   @Test fun `a complex script can be fully parsed`() {
@@ -61,6 +62,7 @@ internal class DependencyExtractorTest {
         fullText = "api(libs.magic)",
       )
     )
+    assertThat(scriptListener.dependencyDeclarationsStatements).containsExactly("api(libs.magic)")
     assertThat(scriptListener.statements).containsExactly(
       "add(\"extraImplementation\", libs.fortyTwo)",
       "val complex = \"a:complex:${'$'}expression\"",

--- a/core/src/test/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractorTest.kt
+++ b/core/src/test/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractorTest.kt
@@ -61,8 +61,8 @@ internal class DependencyExtractorTest {
         fullText = "api(libs.magic)",
       )
     )
-    assertThat(scriptListener.expressions).containsExactly("add(\"extraImplementation\", libs.fortyTwo)")
     assertThat(scriptListener.statements).containsExactly(
+      "add(\"extraImplementation\", libs.fortyTwo)",
       "val complex = \"a:complex:${'$'}expression\"",
       // The whitespace below is a bit wonky, but it's an artifact of the test fixture, not the API.
       """

--- a/core/src/test/kotlin/cash/grammar/kotlindsl/utils/TestListener.kt
+++ b/core/src/test/kotlin/cash/grammar/kotlindsl/utils/TestListener.kt
@@ -25,7 +25,6 @@ internal class TestListener(
   val dependencyExtractor = DependencyExtractor(input, tokens, indent)
 
   val dependencyDeclarations = mutableListOf<DependencyDeclaration>()
-  val expressions = mutableListOf<String>()
   val statements = mutableListOf<String>()
 
   override fun exitNamedBlock(ctx: KotlinParser.NamedBlockContext) {
@@ -39,7 +38,6 @@ internal class TestListener(
       val dependencyContainer = dependencyExtractor.collectDependencies(ctx)
 
       dependencyDeclarations += dependencyContainer.getDependencyDeclarations()
-      expressions += dependencyContainer.getExpressions()
       statements += dependencyContainer.getStatements().map { it.fullText(input)!!.trim() }
     }
   }

--- a/core/src/test/kotlin/cash/grammar/kotlindsl/utils/TestListener.kt
+++ b/core/src/test/kotlin/cash/grammar/kotlindsl/utils/TestListener.kt
@@ -1,6 +1,7 @@
 package cash.grammar.kotlindsl.utils
 
 import cash.grammar.kotlindsl.model.DependencyDeclaration
+import cash.grammar.kotlindsl.model.DependencyDeclarationElement
 import cash.grammar.kotlindsl.utils.Blocks.isBuildscript
 import cash.grammar.kotlindsl.utils.Blocks.isDependencies
 import cash.grammar.kotlindsl.utils.Blocks.isSubprojects
@@ -25,6 +26,7 @@ internal class TestListener(
   val dependencyExtractor = DependencyExtractor(input, tokens, indent)
 
   val dependencyDeclarations = mutableListOf<DependencyDeclaration>()
+  val dependencyDeclarationsStatements = mutableListOf<String>()
   val statements = mutableListOf<String>()
 
   override fun exitNamedBlock(ctx: KotlinParser.NamedBlockContext) {
@@ -38,6 +40,7 @@ internal class TestListener(
       val dependencyContainer = dependencyExtractor.collectDependencies(ctx)
 
       dependencyDeclarations += dependencyContainer.getDependencyDeclarations()
+      dependencyDeclarationsStatements += dependencyContainer.getDependencyDeclarationsWithContext().map { it.statement.fullText(input)!!.trim() }
       statements += dependencyContainer.getStatements().map { it.fullText(input)!!.trim() }
     }
   }


### PR DESCRIPTION
## 📝 Description
We need access to the the ANTLR parsing context in order to manipulate it, as shown in [this example](https://github.com/autonomousapps/dependency-analysis-gradle-plugin/pull/1299/commits/3d5715d28d0fdd62c358f12521c999eca21efe5a#diff-b2a94f740ad8ff6516bf944965d212e085314087d0edc9cc852710ad1ef35c21R121-R123).

This PR refactors the `DependencyExtractor.collectDependencies` to return `DependencyContainer` with either (1) `DependencyDeclarationWithContext` or (2) `StatementContext`. 
