### PR TITLE
chore: prepare for release 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # KotlinEditor
 
+## Version 0.10
+* [feat]: expose `StatementContext` with parsed dependency declarations
+
 ## Version 0.9
 * [feat]: DependencyExtractor includes all statements in DependencyContainer.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ kotlin.stdlib.default.dependency=false
 
 # See BasePlugin
 GROUP=app.cash.kotlin-editor
-VERSION=0.10-SNAPSHOT
+VERSION=0.10


### PR DESCRIPTION
Following instruction in https://github.com/cashapp/kotlin-editor/blob/main/RELEASING.md