### PR TITLE
chore: prepare for release 0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # KotlinEditor
 
+## Version 0.11
+* [feat]: add a utility class to remove comments from a block in a build script.
+
 ## Version 0.10
 * [feat]: expose `StatementContext` with parsed dependency declarations
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ kotlin.stdlib.default.dependency=false
 
 # See BasePlugin
 GROUP=app.cash.kotlin-editor
-VERSION=0.11-SNAPSHOT
+VERSION=0.11


### PR DESCRIPTION
Following instruction in https://github.com/cashapp/kotlin-editor/blob/main/RELEASING.md