### PR TITLE
chore: update publishing code and RELEASING guides.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,16 @@
 Release procedure for KotlinEditor
 
-1. Update CHANGELOG
-1. Update README if needed
+> IMPORTANT. The `recipes/guardrails` project (group: `app.cash.gradle-guard`) configures a `group` and `version` that
+> are different from the default for the rest of the repo. See `recipes/guardrails/RELEASING.md` for separate release
+> instructions.
+
+1. Update `CHANGELOG.md`.
+1. Update `README.md` if needed.
 1. Bump version number in `gradle.properties` to next stable version (removing the `-SNAPSHOT` 
    suffix).
-1. `git commit -am "chore: prepare for release x.y." && git push`
+1. `git commit -am "chore: prepare for release x.y." && git push`.
 1. Publish the snapshot to Maven Central by invoking the `publish` action on github.
-1. `git tag -a vx.y -m "Version x.y."`
-1. Update version number `gradle.properties` to next snapshot version (x.y-SNAPSHOT)
-1. `git commit -am "chore: prepare next development version."`
-1. `git push && git push --tags`
+1. `git tag -a vx.y -m "Version x.y."`.
+1. Update version number `gradle.properties` to next snapshot version (x.y-SNAPSHOT).
+1. `git commit -am "chore: prepare next development version."`.
+1. `git push && git push --tags`.

--- a/build-logic/conventions/src/main/kotlin/com/squareup/gradle/BasePlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/squareup/gradle/BasePlugin.kt
@@ -1,5 +1,6 @@
 package com.squareup.gradle
 
+import com.squareup.gradle.extension.KotlinEditorExtension
 import com.squareup.gradle.utils.DependencyCatalog
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.gradle.api.Project
@@ -20,7 +21,10 @@ internal class BasePlugin(private val project: Project) {
       apply("com.autonomousapps.dependency-analysis")
     }
 
+    KotlinEditorExtension.of(project)
+
     // See gradle.properties
+    // These values may be overridden in individual projects by configuring the `kotlinEditor` extension.
     group = providers.gradleProperty("GROUP").get()
     version = providers.gradleProperty("VERSION").get()
 

--- a/build-logic/conventions/src/main/kotlin/com/squareup/gradle/extension/KotlinEditorExtension.kt
+++ b/build-logic/conventions/src/main/kotlin/com/squareup/gradle/extension/KotlinEditorExtension.kt
@@ -1,0 +1,46 @@
+package com.squareup.gradle.extension
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import javax.inject.Inject
+
+public abstract class KotlinEditorExtension @Inject constructor(private val project: Project) {
+
+  private val publishing = project.extensions.getByType(PublishingExtension::class.java)
+
+  private val group: Property<String> = project.objects.property(String::class.java)
+  private val version: Property<String> = project.objects.property(String::class.java)
+
+  public fun group(group: String) {
+    this.group.set(group)
+    this.group.disallowChanges()
+
+    project.group = group
+
+    // This overwrites the group set in BasePlugin which reads from gradle.properties.
+    publishing.publications
+      .withType(MavenPublication::class.java)
+      .named { it == "maven" }
+      .configureEach { m -> m.groupId = group }
+  }
+
+  public fun version(version: String) {
+    this.version.set(version)
+    this.version.disallowChanges()
+
+    project.version = version
+    // We don't need to configure the publication as with `group` because for some reason `version` is read lazily.
+  }
+
+  internal companion object {
+    fun of(project: Project): KotlinEditorExtension {
+      return project.extensions.create(
+        "kotlinEditor",
+        KotlinEditorExtension::class.java,
+        project,
+      )
+    }
+  }
+}

--- a/recipes/guardrails/CHANGELOG.md
+++ b/recipes/guardrails/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Gradle Guard
+
+## Version 0.1
+* [feat]: Initial release.

--- a/recipes/guardrails/RELEASING.md
+++ b/recipes/guardrails/RELEASING.md
@@ -1,0 +1,12 @@
+Release procedure for Gradle Guard
+
+1. Update `recipes/guardrails/CHANGELOG.md`.
+1. Update `README.md` if needed.
+1. Bump version number in each `build.gradle.kts` in `recipes/guardrails/` to next stable version (removing the 
+   `-SNAPSHOT` suffix).
+1. `git commit -am "chore(gradle-guard): prepare for release x.y." && git push`
+1. Publish the snapshot to Maven Central by invoking the `publish` action on github.
+1. `git tag -a gradle-guard-vx.y -m "Gradle Guard version x.y."`.
+1. Update version number in each `build.gradle.kts` in `recipes/guardrails/` to next snapshot version (`x.y-SNAPSHOT`).
+1. `git commit -am "chore(gradle-guard): prepare next development version."`.
+1. `git push && git push --tags`.

--- a/recipes/guardrails/gradle-guard-lib/build.gradle.kts
+++ b/recipes/guardrails/gradle-guard-lib/build.gradle.kts
@@ -2,8 +2,10 @@ plugins {
   id("cash.lib")
 }
 
-version = "0.1-SNAPSHOT"
-group = "app.cash.gradle-guard"
+kotlinEditor {
+  group("app.cash.gradle-guard")
+  version("0.1-SNAPSHOT")
+}
 
 dependencies {
   api(libs.kotlinStdLib)

--- a/recipes/guardrails/gradle-guard/build.gradle.kts
+++ b/recipes/guardrails/gradle-guard/build.gradle.kts
@@ -2,8 +2,10 @@ plugins {
   id("cash.app")
 }
 
-version = "0.1-SNAPSHOT"
-group = "app.cash.gradle-guard"
+kotlinEditor {
+  group("app.cash.gradle-guard")
+  version("0.1-SNAPSHOT")
+}
 
 application {
   mainClass = "cash.recipes.lint.cli.Main"


### PR DESCRIPTION
Setting up to publish https://github.com/cashapp/kotlin-editor/pull/40.

That PR will require publishing the core libs first, then publishing the new guardrails projects. After that, I can proceed with packing it all up in a hermit binary.