### PR TITLE
fix(gradle-guard): respect the generated baseline.

### DIFF
--- a/recipes/guardrails/gradle-guard-lib/src/main/kotlin/cash/recipes/lint/buildscripts/config/YamlSpec.kt
+++ b/recipes/guardrails/gradle-guard-lib/src/main/kotlin/cash/recipes/lint/buildscripts/config/YamlSpec.kt
@@ -8,17 +8,33 @@ public class YamlSpec(public val lintConfig: LintConfig) : AllowList.Spec {
   private val ignoredPaths = lintConfig.getIgnoredPaths().map { Path.of(it) }
 
   override fun test(path: Path, stmt: Statement): Boolean {
-    if (ignoredPaths.any { path.startsWith(it) }) {
+    if (isIgnoredPath(path)) {
       return true
     }
 
     return when (stmt) {
-      is Statement.NamedBlock -> stmt.name in lintConfig.getAllowedBlocks()
-      else -> lintConfig.getAllowedPrefixes().any { prefix -> stmt.text.startsWith(prefix) }
+      is Statement.NamedBlock -> stmt.name in getAllowedBlocksFor(path)
+      else -> getAllowedPrefixesFor(path).any { prefix -> stmt.text.startsWith(prefix) }
     }
   }
 
+  private fun getAllowedBlocksFor(path: Path): Set<String> {
+    return lintConfig.getAllowedBlocks() + findBaseline(path)?.getAllowedBlocks().orEmpty()
+  }
+
+  private fun getAllowedPrefixesFor(path: Path): Set<String> {
+    return lintConfig.getAllowedPrefixes() + findBaseline(path)?.getAllowedPrefixes().orEmpty()
+  }
+
+  private fun findBaseline(path: Path): BaselineConfig? {
+    return lintConfig.getBaseline().firstOrNull { it.getPath() == path.toString() }
+  }
+
   override fun test(path: Path): Boolean {
+    return isIgnoredPath(path)
+  }
+
+  private fun isIgnoredPath(path: Path): Boolean {
     return ignoredPaths.any { path.startsWith(it) }
   }
 

--- a/recipes/guardrails/gradle-guard-lib/src/test/kotlin/cash/recipes/lint/buildscripts/utils/BuildScripts.kt
+++ b/recipes/guardrails/gradle-guard-lib/src/test/kotlin/cash/recipes/lint/buildscripts/utils/BuildScripts.kt
@@ -65,4 +65,14 @@ internal object BuildScripts {
         }
       }
     """.trimIndent()
+
+  val baseline = """
+    plugins {
+      id("java")
+    }
+ 
+    val host = System.getenv("OST") ?: "localhost"
+    val port = System.getenv("PORT") ?: "1234"
+
+  """.trimIndent()
 }


### PR DESCRIPTION
The code had previously been ignoring all the config in the baseline property.