### PR TITLE
fix: no-error human-readable report contains trailing newline.

### DIFF
--- a/recipes/guardrails/gradle-guard-lib/src/main/kotlin/cash/recipes/lint/buildscripts/reporter/HumanReadableReporter.kt
+++ b/recipes/guardrails/gradle-guard-lib/src/main/kotlin/cash/recipes/lint/buildscripts/reporter/HumanReadableReporter.kt
@@ -38,7 +38,7 @@ public class HumanReadableReporter private constructor(
 
     return if (reports.reports.all { it.statements.isEmpty() }) {
       // The case where there are no violations anywhere
-      "None of the build scripts contain forbidden statements."
+      "None of the build scripts contain forbidden statements.\n"
     } else if (reports.reports.size == 1) {
       // The case where there is only a single file analyzed
       val report = reports.reports.single()

--- a/recipes/guardrails/gradle-guard-lib/src/test/kotlin/cash/recipes/lint/buildscripts/reporter/HumanReadableReporterTest.kt
+++ b/recipes/guardrails/gradle-guard-lib/src/test/kotlin/cash/recipes/lint/buildscripts/reporter/HumanReadableReporterTest.kt
@@ -30,7 +30,7 @@ internal class HumanReadableReporterTest {
     // Then
     val messages = logger.getMessages()
     assertThat(messages).size().isEqualTo(1)
-    assertThat(messages.single()).isEqualTo("None of the build scripts contain forbidden statements.")
+    assertThat(messages.single().trim()).isEqualTo("None of the build scripts contain forbidden statements.")
   }
 
   @Test


### PR DESCRIPTION
Better console output this way.