### PR TITLE
fix: handle no-arg project dependency declarations.

### DIFF
--- a/core/src/main/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractor.kt
+++ b/core/src/main/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractor.kt
@@ -379,6 +379,16 @@ public class DependencyExtractor(
       .valueArguments()
       .valueArgument()
 
+    // A declaration like `project()` (meaning _this_ project, the main source).
+    if (args.isEmpty()) {
+      return if (text == "project()") {
+        text.asSimpleIdentifier()
+      } else {
+        // Unclear what this is
+        error("Unknown type of dependency declaration. Text = `${fullText(input)}`")
+      }
+    }
+
     // 1. possibly a simple identifier, like `g:a:v`, or
     // 2. `path = "foo"`
     if (args.size == 1) {
@@ -402,7 +412,7 @@ public class DependencyExtractor(
     }
 
     // Unclear what this would be, bail
-    if (args.size > 2) {
+    if (args.size != 2) {
       return null
     }
 

--- a/core/src/test/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractorTest.kt
+++ b/core/src/test/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractorTest.kt
@@ -32,7 +32,8 @@ internal class DependencyExtractorTest {
     assertThat(scriptListener.dependencyDeclarationsStatements).containsExactly(testCase.fullText)
   }
 
-  @Test fun `a complex script can be fully parsed`() {
+  @Test
+  fun `a complex script can be fully parsed`() {
     // Given
     val buildScript = """
       dependencies {
@@ -78,7 +79,8 @@ internal class DependencyExtractorTest {
     )
   }
 
-  @Test fun `can parse complex declarations`() {
+  @Test
+  fun `can parse complex declarations`() {
     // Given
     val buildScript = """
       dependencies {
@@ -123,6 +125,36 @@ internal class DependencyExtractorTest {
     )
   }
 
+  @Test
+  fun `can parse a project() dependency`() {
+    // Given
+    val buildScript = """
+      testing.suites {
+        register("compatibilityTest", JvmTestSuite::class) {
+          useJUnitJupiter(libs.versions.junit.jupiter)
+      
+          dependencies {
+            implementation(project())
+          }
+        }
+      }
+    """.trimIndent()
+
+    // When
+    val scriptListener = listenerFor(buildScript)
+
+    // Then
+    assertThat(scriptListener.dependencyDeclarations).containsExactly(
+      DependencyDeclaration(
+        configuration = "implementation",
+        identifier = "project()".asSimpleIdentifier()!!,
+        capability = Capability.DEFAULT,
+        type = Type.PROJECT,
+        fullText = "implementation(project())",
+      )
+    )
+  }
+
   private fun listenerFor(buildScript: String): TestListener {
     return Parser(
       file = buildScript,
@@ -134,7 +166,8 @@ internal class DependencyExtractorTest {
   }
 
   private companion object {
-    @JvmStatic fun declarations(): List<TestCase> = listOf(
+    @JvmStatic
+    fun declarations(): List<TestCase> = listOf(
       TestCase(
         displayName = "raw string coordinates",
         fullText = "api(\"g:a:v\")",


### PR DESCRIPTION
These are declarations of a dependency on the main source (as from a custom source set, like a test).

First step in resolving https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1633.