### PR TITLE
feat: BaselineConfig is now fully Comparable.

### DIFF
--- a/recipes/guardrails/gradle-guard-lib/src/main/kotlin/cash/recipes/lint/buildscripts/config/BaselineConfig.kt
+++ b/recipes/guardrails/gradle-guard-lib/src/main/kotlin/cash/recipes/lint/buildscripts/config/BaselineConfig.kt
@@ -1,21 +1,24 @@
 package cash.recipes.lint.buildscripts.config
 
+import cash.recipes.lint.buildscripts.utils.comparable.LexicographicIterableComparator
+
 /** @see [LintConfig] */
 public data class BaselineConfig(
   private val path: String,
   private val allowedBlocks: Set<String>? = null,
   private val allowedPrefixes: Set<String>? = null,
-) {
+) : Comparable<BaselineConfig> {
 
-  internal companion object {
-    val PATH_COMPARATOR = Comparator<BaselineConfig> { left, right ->
-      left.path.compareTo(right.path)
-    }
+  override fun compareTo(other: BaselineConfig): Int {
+    return compareBy(BaselineConfig::getPath)
+      .thenBy(LexicographicIterableComparator()) { it.getAllowedBlocks() }
+      .thenBy(LexicographicIterableComparator()) { it.getAllowedPrefixes() }
+      .compare(this, other)
   }
 
   public fun getPath(): String = path
 
-  public fun getAllowedBlocks(): Set<String> = allowedBlocks.orEmpty()
+  public fun getAllowedBlocks(): Set<String> = allowedBlocks.orEmpty().toSortedSet()
 
-  public fun getAllowedPrefixes(): Set<String> = allowedPrefixes.orEmpty()
+  public fun getAllowedPrefixes(): Set<String> = allowedPrefixes.orEmpty().toSortedSet()
 }

--- a/recipes/guardrails/gradle-guard-lib/src/main/kotlin/cash/recipes/lint/buildscripts/config/LintConfig.kt
+++ b/recipes/guardrails/gradle-guard-lib/src/main/kotlin/cash/recipes/lint/buildscripts/config/LintConfig.kt
@@ -69,14 +69,14 @@ public data class LintConfig(
 
   public fun getIgnoredPaths(): Set<String> = ignoredPaths?.toSortedSet().orEmpty()
 
-  public fun getBaseline(): Set<BaselineConfig> = baseline?.toSortedSet(BaselineConfig.PATH_COMPARATOR).orEmpty()
+  public fun getBaseline(): Set<BaselineConfig> = baseline?.toSortedSet().orEmpty()
 
   internal fun merge(other: LintConfig): LintConfig {
     return LintConfig(
       allowedBlocks = (getAllowedBlocks() + other.getAllowedBlocks()).toSortedSet(),
       allowedPrefixes = (getAllowedPrefixes() + other.getAllowedPrefixes()).toSortedSet(),
       ignoredPaths = (getIgnoredPaths() + other.getIgnoredPaths()).toSortedSet(),
-      baseline = (getBaseline() + other.getBaseline()),
+      baseline = (getBaseline() + other.getBaseline()).toSortedSet(),
     )
   }
 
@@ -128,7 +128,7 @@ public data class LintConfig(
             )
           }
         }
-        .toSortedSet(BaselineConfig.PATH_COMPARATOR)
+        .toSortedSet()
 
       return LintConfig(baseline = baseline)
     }

--- a/recipes/guardrails/gradle-guard-lib/src/main/kotlin/cash/recipes/lint/buildscripts/utils/comparable/LexicographicIterableComparator.kt
+++ b/recipes/guardrails/gradle-guard-lib/src/main/kotlin/cash/recipes/lint/buildscripts/utils/comparable/LexicographicIterableComparator.kt
@@ -1,0 +1,26 @@
+// Copyright (c) 2025. Tony Robalik.
+// SPDX-License-Identifier: Apache-2.0
+// Taken directly fom https://github.com/autonomousapps/dependency-analysis-gradle-plugin/blob/d42dd3122e090491ce705d153588956ffe92b600/src/main/kotlin/com/autonomousapps/internal/utils/comparators.kt#L5
+package cash.recipes.lint.buildscripts.utils.comparable
+
+internal class LexicographicIterableComparator<T : Comparable<T>> : Comparator<Iterable<T>> {
+  override fun compare(left: Iterable<T>?, right: Iterable<T>?): Int {
+    if (left === right) return 0
+    if (left == null || right == null) return if (left == null) -1 else 1
+
+    val leftIterator = left.iterator()
+    val rightIterator = right.iterator()
+
+    while (leftIterator.hasNext() && rightIterator.hasNext()) {
+      val compareResult = leftIterator.next().compareTo(rightIterator.next())
+      if (compareResult != 0) {
+        return compareResult
+      }
+    }
+
+    if (leftIterator.hasNext()) return 1
+    if (rightIterator.hasNext()) return -1
+
+    return 0
+  }
+}


### PR DESCRIPTION
I noticed that when merging baselines, the order of allowed_prefixes was changing. This should resolve that.