### PR TITLE
test: add test case validating correct parsing of version catalog workaround.

### DIFF
--- a/core/src/test/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractorTest.kt
+++ b/core/src/test/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractorTest.kt
@@ -284,6 +284,14 @@ internal class DependencyExtractorTest {
         capability = Capability.DEFAULT,
         type = Type.GRADLE_DISTRIBUTION,
       ),
+      TestCase(
+        displayName = "version-catalog-workaround",
+        fullText = "implementation(files(libs::class.java.superclass.protectionDomain.codeSource.location))",
+        configuration = "implementation",
+        identifier = "libs::class.java.superclass.protectionDomain.codeSource.location",
+        capability = Capability.DEFAULT,
+        type = Type.FILES,
+      ),
     )
   }
 


### PR DESCRIPTION
See https://github.com/square/gradle-dependencies-sorter/issues/136
See https://github.com/square/gradle-dependencies-sorter/pull/145