### PR TITLE
fix: handle dependency declaration on the output of one of a project's sourceSets.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,19 +22,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
 
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # 5.2.0
         with:
           distribution: 'zulu'
           java-version: 17
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
-
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # 6.1.0
 
       - name: Execute check
         run: './gradlew check -s'

--- a/.github/workflows/publish-gradle-guard.yml
+++ b/.github/workflows/publish-gradle-guard.yml
@@ -26,19 +26,16 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
 
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # 5.2.0
         with:
           distribution: 'zulu'
           java-version: 17
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
-
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # 6.1.0
 
       - name: Execute check
         run: './gradlew check -s'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,19 +22,16 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
 
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # 5.2.0
         with:
           distribution: 'zulu'
           java-version: 17
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
-
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # 6.1.0
 
       - name: Execute check
         run: './gradlew check -s'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,19 +24,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
 
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # 5.2.0
         with:
           distribution: 'zulu'
           java-version: 17
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
-
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # 6.1.0
 
       - name: Execute check
         run: './gradlew check -s'

--- a/.github/workflows/release-gradle-guard.yml
+++ b/.github/workflows/release-gradle-guard.yml
@@ -26,19 +26,16 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
 
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # 5.2.0
         with:
           distribution: 'zulu'
           java-version: 17
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
-
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # 6.1.0
 
       - name: Prepare zip for Github Release
         run: './gradlew -p recipes/guardrails/gradle-guard distZip -Pcashapp.gradle-guard-version=${{ needs.release_version.outputs.version }} -s'

--- a/core/src/main/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractor.kt
+++ b/core/src/main/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractor.kt
@@ -374,7 +374,16 @@ public class DependencyExtractor(
   }
 
   private fun PostfixUnaryExpressionContext.findIdentifier(): Identifier? {
-    val args = postfixUnarySuffix().single()
+    val suffixes = postfixUnarySuffix()
+
+    // https://github.com/square/gradle-dependencies-sorter/issues/148
+    // E.g., `project.sourceSets["test"].output (size == 3)
+    if (suffixes.size > 1) {
+      // Bail out and treat the whole thing as the "identifier."
+      return text.asSimpleIdentifier()
+    }
+
+    val args = suffixes.single()
       .callSuffix()
       .valueArguments()
       .valueArgument()

--- a/core/src/test/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractorTest.kt
+++ b/core/src/test/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractorTest.kt
@@ -155,6 +155,49 @@ internal class DependencyExtractorTest {
     )
   }
 
+  // project.sourcesets["test"].output is a `FileCollection`. It's also a `PostfixUnaryExpression` that has three
+  // `PostfixUnarySuffix`es after its `PrimaryExpression`.
+  // https://github.com/square/gradle-dependencies-sorter/issues/148
+  @Test
+  fun `can parse a a sourceSet output`() {
+    // Given
+    val buildScript = """
+        testing {
+          suites {
+            val testReceiveSpansDisabled by registering(JvmTestSuite::class) {
+              dependencies {
+                implementation(project(":instrumentation:spring:spring-jms:spring-jms-2.0:testing"))
+                // has three PostfixUnarySuffixes
+                implementation(project.sourceSets["test"].output)
+              }
+            }
+          }
+        }
+    """.trimIndent()
+
+    // When
+    val scriptListener = listenerFor(buildScript)
+
+    // Then
+    assertThat(scriptListener.dependencyDeclarations).containsExactly(
+      DependencyDeclaration(
+        configuration = "implementation",
+        identifier = "\":instrumentation:spring:spring-jms:spring-jms-2.0:testing\"".asSimpleIdentifier()!!,
+        capability = Capability.DEFAULT,
+        type = Type.PROJECT,
+        fullText = "implementation(project(\":instrumentation:spring:spring-jms:spring-jms-2.0:testing\"))",
+      ),
+      DependencyDeclaration(
+        configuration = "implementation",
+        identifier = "project.sourceSets[\"test\"].output".asSimpleIdentifier()!!,
+        capability = Capability.DEFAULT,
+        type = Type.PROJECT,
+        fullText = "implementation(project.sourceSets[\"test\"].output)",
+        precedingComment = "// has three PostfixUnarySuffixes",
+      ),
+    )
+  }
+
   private fun listenerFor(buildScript: String): TestListener {
     return Parser(
       file = buildScript,


### PR DESCRIPTION
E.g.,
```
project.sourceSets[test].output
```

Also updated GH Actions to latest.

First step in resolving https://github.com/square/gradle-dependencies-sorter/issues/148.