### PR TITLE
Support parsing of `dependencies` block with dot syntax

### DIFF
--- a/core/src/main/kotlin/cash/grammar/kotlindsl/utils/BlockRemover.kt
+++ b/core/src/main/kotlin/cash/grammar/kotlindsl/utils/BlockRemover.kt
@@ -40,7 +40,7 @@ public class BlockRemover private constructor(
   override fun exitNamedBlock(ctx: KotlinParser.NamedBlockContext) {
     val simpleBlocks = blocksToRemove.filterIsInstance<RemovableBlock.SimpleBlock>()
 
-    if (ctx.name().text in simpleBlocks.map { it.name }) {
+    if (ctx.name().last().text in simpleBlocks.map { it.name }) {
       // delete whole block and spaces around it
       rewriter.delete(ctx.start, ctx.stop)
       rewriter.deleteWhitespaceToLeft(ctx.start)

--- a/core/src/main/kotlin/cash/grammar/kotlindsl/utils/Blocks.kt
+++ b/core/src/main/kotlin/cash/grammar/kotlindsl/utils/Blocks.kt
@@ -17,16 +17,16 @@ public object Blocks {
   public const val SUBPROJECTS: String = "subprojects"
 
   public val NamedBlockContext.isAllprojects: Boolean
-    get() = name().text == ALLPROJECTS
+    get() = name().last().text == ALLPROJECTS
 
   public val NamedBlockContext.isBuildscript: Boolean
-    get() = name().text == BUILDSCRIPT
+    get() = name().last().text == BUILDSCRIPT
 
   public val NamedBlockContext.isDependencies: Boolean
-    get() = name().text == DEPENDENCIES
+    get() = name().last().text == DEPENDENCIES
 
   public val NamedBlockContext.isDependencyResolutionManagement: Boolean
-    get() = name().text == DEPENDENCY_RESOLUTION_MANAGEMENT
+    get() = name().last().text == DEPENDENCY_RESOLUTION_MANAGEMENT
 
   /**
    * Returns true if this is the top-level "plugins" block. False otherwise. In particular, will
@@ -38,13 +38,13 @@ public object Blocks {
    * ```
    */
   public val NamedBlockContext.isPlugins: Boolean
-    get() = name().text == PLUGINS && isTopLevel(this)
+    get() = name().last().text == PLUGINS && isTopLevel(this)
 
   public val NamedBlockContext.isRepositories: Boolean
-    get() = name().text == REPOSITORIES
+    get() = name().last().text == REPOSITORIES
 
   public val NamedBlockContext.isSubprojects: Boolean
-    get() = name().text == SUBPROJECTS
+    get() = name().last().text == SUBPROJECTS
 
   /**
    * Returns the outermost block relative to the current block, represented by the block at the top
@@ -163,7 +163,7 @@ public object Blocks {
     var parent = ctx.parent
     while (parent !is ScriptContext) {
       if (parent is NamedBlockContext) {
-        val parentName = parent.name().text
+        val parentName = parent.name().last().text
         if (name == null || parentName == name) {
           return parentName
         }
@@ -186,7 +186,7 @@ public object Blocks {
     action: (NamedBlockContext) -> Unit
   ) {
     iter.mapNotNull { it.namedBlock() }
-      .filter { name == null || it.name().text == name }
+      .filter { name == null || it.name().last().text == name }
       .forEach { action(it) }
   }
 }

--- a/core/src/main/kotlin/cash/grammar/kotlindsl/utils/CommentsInBlockRemover.kt
+++ b/core/src/main/kotlin/cash/grammar/kotlindsl/utils/CommentsInBlockRemover.kt
@@ -66,7 +66,7 @@ public class CommentsInBlockRemover private constructor(
   }
 
   override fun exitNamedBlock(ctx: KotlinParser.NamedBlockContext) {
-    if (ctx.name().text == blockName) {
+    if (ctx.name().last().text == blockName) {
       // Delete inline comments (a comment after a statement)
       val allInlineComments = mutableListOf<Token>()
       ctx.statements().statement().forEach {

--- a/core/src/main/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractor.kt
+++ b/core/src/main/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractor.kt
@@ -50,7 +50,7 @@ public class DependencyExtractor(
    */
   public fun collectDependencies(ctx: NamedBlockContext): DependencyContainer {
     require(ctx.isDependencies) {
-      "Expected dependencies block. Was '${ctx.name().text}'"
+      "Expected dependencies block. Was '${ctx.name().last().text}'"
     }
 
     val statements = ctx.statements().statement()

--- a/core/src/main/kotlin/cash/grammar/kotlindsl/utils/PluginExtractor.kt
+++ b/core/src/main/kotlin/cash/grammar/kotlindsl/utils/PluginExtractor.kt
@@ -32,7 +32,7 @@ public object PluginExtractor {
    */
   public fun scriptLikeContext(blockStack: ArrayDeque<NamedBlockContext>): Boolean {
     val isAllprojectsBlock = blockStack.firstOrNull { namedBlock ->
-      namedBlock.name().text in pluginScriptBlocks
+      namedBlock.name().last().text in pluginScriptBlocks
     } != null
 
     return !(blockStack.size > 1 || (blockStack.size == 1 && !isAllprojectsBlock))

--- a/core/src/test/kotlin/cash/grammar/kotlindsl/utils/BlocksTest.kt
+++ b/core/src/test/kotlin/cash/grammar/kotlindsl/utils/BlocksTest.kt
@@ -32,7 +32,7 @@ internal class BlocksTest {
     ).listener()
 
     assertThat(scriptListener.outermostBlock).isNotNull()
-    assertThat(scriptListener.outermostBlock!!.name().text).isEqualTo(Blocks.SUBPROJECTS)
+    assertThat(scriptListener.outermostBlock!!.name().last().text).isEqualTo(Blocks.SUBPROJECTS)
   }
 
   @Test fun `outermost block containing 'repositories' is 'buildscript'`() {
@@ -55,7 +55,7 @@ internal class BlocksTest {
     ).listener()
 
     assertThat(scriptListener.outermostBlock).isNotNull()
-    assertThat(scriptListener.outermostBlock!!.name().text).isEqualTo(Blocks.BUILDSCRIPT)
+    assertThat(scriptListener.outermostBlock!!.name().last().text).isEqualTo(Blocks.BUILDSCRIPT)
   }
 
   @Test fun `can get enclosing blocks`() {
@@ -101,7 +101,7 @@ internal class BlocksTest {
     val blocks = mutableListOf<String>()
     buildScript.process { script ->
       Blocks.forEachNamedBlock(script.statement()) { block ->
-        blocks.add(block.name().text)
+        blocks.add(block.name().last().text)
       }
     }
 

--- a/core/src/test/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractorTest.kt
+++ b/core/src/test/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractorTest.kt
@@ -198,6 +198,33 @@ internal class DependencyExtractorTest {
     )
   }
 
+  // https://github.com/square/gradle-dependencies-sorter/issues/153
+  @Test
+  fun `can parse dependency declarations using dot syntax`() {
+    // Given
+    val buildScript = """
+        kotlin {
+          sourceSets.commonMain.dependencies {
+            api(projects.redwoodLayoutWidget)
+          }
+        }
+    """.trimIndent()
+
+    // When
+    val scriptListener = listenerFor(buildScript)
+
+    // Then
+    assertThat(scriptListener.dependencyDeclarations).containsExactly(
+      DependencyDeclaration(
+        configuration = "api",
+        identifier = "projects.redwoodLayoutWidget".asSimpleIdentifier()!!,
+        capability = Capability.DEFAULT,
+        type = Type.MODULE,
+        fullText = "api(projects.redwoodLayoutWidget)",
+      ),
+    )
+  }
+
   private fun listenerFor(buildScript: String): TestListener {
     return Parser(
       file = buildScript,

--- a/core/src/test/kotlin/cash/grammar/kotlindsl/utils/TestListener.kt
+++ b/core/src/test/kotlin/cash/grammar/kotlindsl/utils/TestListener.kt
@@ -45,6 +45,6 @@ internal class TestListener(
       statements += dependencyContainer.getStatements().map { it.fullText(input)!!.trim() }
     }
 
-    commentTokens[ctx.name().text] = comments.getCommentsInBlock(ctx)
+    commentTokens[ctx.name().last().text] = comments.getCommentsInBlock(ctx)
   }
 }

--- a/grammar/src/main/antlr/com/squareup/cash/grammar/KotlinParser.g4
+++ b/grammar/src/main/antlr/com/squareup/cash/grammar/KotlinParser.g4
@@ -66,7 +66,7 @@ declaration
 // SECTION: Gradle script blocks
 
 namedBlock
-    : name LCURL NL* statements NL* RCURL
+    : name (NL* DOT name)* LCURL NL* statements NL* RCURL
     ;
 
 name


### PR DESCRIPTION
A Kotlin Script equivalent to https://github.com/autonomousapps/gradle-script-grammar/pull/5.