### PR TITLE
chore: prepare for release 0.23.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # KotlinEditor
 
+## Version 0.23
+* [feat]: support parsing KMP-style dependencies blocks.
+
 ## Version 0.22
 * [fix]: handle dependency declaration on the output of one of a project's sourceSets. E.g., 
   `project.sourceSets["test"].output`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,4 +11,4 @@ kotlin.stdlib.default.dependency=false
 
 # See BasePlugin
 GROUP=app.cash.kotlin-editor
-VERSION=0.23-SNAPSHOT
+VERSION=0.23


### PR DESCRIPTION
https://github.com/cashapp/kotlin-editor/pull/59