### PR TITLE
Parse type-safe project dependencies as PROJECT type

### DIFF
--- a/core/src/main/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractor.kt
+++ b/core/src/main/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractor.kt
@@ -203,7 +203,11 @@ public class DependencyExtractor(
           }
         }
       } else if (args == null) {
-        // We're looking at something like `libs.kotlinGradleBom`
+        if (leaf.primaryExpression().text == "projects") {
+          // We're looking at a type-safe project dependency, like `projects.mymodule`
+          type = DependencyDeclaration.Type.PROJECT
+        }
+        // We're looking at something like `libs.kotlinGradleBom` or `projects.mymodule`
         identifier = leaf.text.asSimpleIdentifier()
       }
     } else if (leaf is SimpleIdentifierContext) {

--- a/core/src/test/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractorTest.kt
+++ b/core/src/test/kotlin/cash/grammar/kotlindsl/utils/DependencyExtractorTest.kt
@@ -198,9 +198,33 @@ internal class DependencyExtractorTest {
     )
   }
 
-  // https://github.com/square/gradle-dependencies-sorter/issues/153
   @Test
   fun `can parse dependency declarations using dot syntax`() {
+    // Given
+    val buildScript = """
+        dependencies {
+          api(projects.redwoodLayoutWidget)
+        }
+    """.trimIndent()
+
+    // When
+    val scriptListener = listenerFor(buildScript)
+
+    // Then
+    assertThat(scriptListener.dependencyDeclarations).containsExactly(
+      DependencyDeclaration(
+        configuration = "api",
+        identifier = "projects.redwoodLayoutWidget".asSimpleIdentifier()!!,
+        capability = Capability.DEFAULT,
+        type = Type.PROJECT,
+        fullText = "api(projects.redwoodLayoutWidget)",
+      ),
+    )
+  }
+
+  // https://github.com/square/gradle-dependencies-sorter/issues/153
+  @Test
+  fun `can parse multiplatform dependency declarations using dot syntax`() {
     // Given
     val buildScript = """
         kotlin {
@@ -219,7 +243,7 @@ internal class DependencyExtractorTest {
         configuration = "api",
         identifier = "projects.redwoodLayoutWidget".asSimpleIdentifier()!!,
         capability = Capability.DEFAULT,
-        type = Type.MODULE, // TODO(tsr): this should be `Type.PROJECT`
+        type = Type.PROJECT,
         fullText = "api(projects.redwoodLayoutWidget)",
       ),
     )


### PR DESCRIPTION
Adds support for Gradle's [type-safe project accessors API](https://docs.gradle.org/current/userguide/declaring_dependencies_basics.html#sec:type-safe-project-accessors).